### PR TITLE
Add single docroot scan option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Usage
 ```bash
-./wp_core_check.sh [--repair] [--force] [--dry-run] [--append] [--log-file=FILE] [--wp-cli=PATH] [--tidy] [--base-dir=DIR] [--docroot=DIR] [--no-symlinks] [--help]
+./wp_core_check.sh [--repair] [--force] [--dry-run] [--append] [--log-file=FILE] [--wp-cli=PATH] [--tidy] [--base-dir=DIR] [--docroot=DIR] [--single-docroot=DIR] [--no-symlinks] [--help]
 ```
 
 ### Options
@@ -32,6 +32,7 @@
 - `--tidy` &mdash; remove inactive themes and plugins after verification.
 - `--base-dir=DIR` &mdash; base directory containing site folders.
 - `--docroot=DIR` &mdash; name of the docroot folder inside each site (defaults to `web`).
+- `--single-docroot=DIR` &mdash; scan only the specified docroot path.
 - `--no-symlinks` &mdash; skip directories that are symlinks.
 - `--help` &mdash; display usage information and exit.
 
@@ -45,6 +46,7 @@ Progress and results are timestamped and written to the specified log file. Use 
 
 ## Directory layout
 By default the script scans all directories under `/var/www/clients/client1` and expects each site to have a `web/` docroot. Both the base directory and docroot name can be changed with `--base-dir` and `--docroot`. Use `--no-symlinks` to skip any directories that are symbolic links.
+Use `--single-docroot` to target a specific site directly.
 
 ## License
 No explicit license is provided for this project.


### PR DESCRIPTION
## Summary
- introduce `--single-docroot` flag to target a specific site
- document the new option in `README.md`
- refactor main loop into `scan_site` function

## Testing
- `bash -n wp_core_check.sh`


------
https://chatgpt.com/codex/tasks/task_b_685f7782064c832a86069e860079bf62